### PR TITLE
Adding the actual job description and job name to graph if set

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/buildgraphview/BuildExecution/build-step.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildgraphview/BuildExecution/build-step.jelly
@@ -8,9 +8,12 @@
         style="background-color: ${it.build.iconColor.htmlBaseColor};">
 
         <div class="title">
-            <a href="${it.buildUrl}">${it}</a>
+            <a href="${it.buildUrl}">${it.build.fullDisplayName}</a>
         </div>
         <div class="details">
+            <j:if test="${!empty(it.build.description)}">
+                ${it.build.description}<br/>
+            </j:if>            
             <j:choose>
             <j:when test="${it.started}">
                 <j:choose>


### PR DESCRIPTION
This is a small adaptation to the Build Flow Plugin graph. It adds the actual job description and job name if this is set. Only the jelly-script is updated.

Using this script:
build.setDescription("My flow description")
build.setDisplayName("MyName")

test1 = build("Test1").build
test1.setDescription("Description set by user")
test1.setDisplayName("NameMe")
test1.setDescription()

test2 = build("Test2").build
test2.setDescription("Description set by user")
test2.setDisplayName("NameMe")
test2.setDisplayName()

build("Test1").build

Will create the following graph:
![build_flow_naming](https://f.cloud.github.com/assets/4181469/430087/0fd03a0a-ae5d-11e2-819d-ab9333e5a6ac.png)
