### PR TITLE
Possible to use html-tags in description

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/buildgraphview/BuildExecution/build-step.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildgraphview/BuildExecution/build-step.jelly
@@ -12,7 +12,7 @@
         </div>
         <div class="details">
             <j:if test="${!empty(it.build.description)}">
-                <j:out value="${it.build.description}"/><br/>
+                <j:out value="${app.markupFormatter.translate(it.build.description)}" />
             </j:if>            
             <j:choose>
             <j:when test="${it.started}">


### PR DESCRIPTION
Not sure if this is a security issue? 
https://wiki.jenkins-ci.org/display/JENKINS/Jelly+and+XSS+prevention

Anyway, this pull-request makes it possible to use html-tags in the description.

![build_flow_html](https://f.cloud.github.com/assets/4181469/454477/2dfb8386-b33a-11e2-85c0-6286dc30cbec.png)
