### PR TITLE
Serialize Buildgraph

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildgraphview/BuildExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/buildgraphview/BuildExecution.java
@@ -1,19 +1,43 @@
 package org.jenkinsci.plugins.buildgraphview;
 
+import hudson.model.BallColor;
 import hudson.model.Run;
 
+import java.io.Serializable;
 import java.text.DateFormat;
 
 /**
  * A wrapper on a AbstractBuild that maintains additional layout information, used during graphical rendering.
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class BuildExecution {
+public class BuildExecution implements Serializable {
 
     private transient Run build;
 
     // A unique number that identifies when in the FlowAbstractBuild this job was started
     private final int buildIndex;
+
+    private String id;
+
+    private String buildUrl;
+
+    private String startTime;
+
+    private String buildName;
+
+    private String buildNumber;
+
+    private BallColor iconColor;
+
+    private String fullDisplayName;
+
+    private String description;
+
+    private boolean building;
+
+    private String durationString;
+
+    private String buildSummaryStatusString;
 
     private int displayColumn;
 
@@ -22,19 +46,63 @@ public class BuildExecution {
     public BuildExecution(Run build, int buildIndex) {
         this.build = build;
         this.buildIndex = buildIndex;
+        this.id = "build-" + buildIndex;
+        this.buildUrl = this.build != null ? this.build.getAbsoluteUrl() : null;
+        this.startTime = isStarted() ? DateFormat.getDateTimeInstance(
+                DateFormat.SHORT, DateFormat.SHORT).format(build.getTime())
+                : "";
+        this.buildName = build.getParent().getName();
+        this.buildNumber = "" + build.number;
+        this.iconColor = build.getIconColor();
+        this.fullDisplayName = build.getFullDisplayName();
+        this.description = build.getDescription();
+        this.building = build.isBuilding();
+        this.durationString = build.getDurationString();
+        this.buildSummaryStatusString = build.getBuildStatusSummary().message;
+    }
+
+    public BuildExecution(int buildIndex) {
+        this.buildIndex = buildIndex;
+    }
+
+    public BallColor getIconColor() {
+        return iconColor;
+    }
+
+    public String getFullDisplayName() {
+        return fullDisplayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean getBuilding() {
+        return building;
+    }
+
+    public String getDurationString() {
+        return durationString;
+    }
+
+    public String getbuildSummaryStatusString() {
+        return buildSummaryStatusString;
     }
 
     public String getId() {
-        return "build-" + buildIndex;
+        return id;
     }
 
     public String getBuildUrl() {
-        return this.build != null ? this.build.getAbsoluteUrl() : null;
+        return buildUrl;
     }
 
     public String getStartTime() {
+        if(build == null) {
+            return startTime;
+        }
         if (isStarted()) {
-            return DateFormat.getDateTimeInstance(
+            return startTime = DateFormat.getDateTimeInstance(
                     DateFormat.SHORT,
                     DateFormat.SHORT)
                     .format(build.getTime());
@@ -43,7 +111,7 @@ public class BuildExecution {
     }
 
     public boolean isStarted() {
-        return build.getTime() != null;
+        return build != null ? build.getTime() != null : true;
     }
 
     public Run<?,?> getBuild() {
@@ -71,7 +139,7 @@ public class BuildExecution {
     }
 
     public String toString() {
-        return (build != null ? build.getParent().getName() + " #" + build.number : "");
+        return (buildName != null && buildNumber != null ? buildName + " #" + buildNumber : "");
     }
 
     @Override
@@ -84,6 +152,9 @@ public class BuildExecution {
 
     @Override
     public int hashCode() {
-        return build.hashCode();
+        if (build != null) {
+            return build.hashCode();
+        }
+        return super.hashCode();
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/buildgraphview/BuildExecution/build-step.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildgraphview/BuildExecution/build-step.jelly
@@ -7,24 +7,24 @@
         data-row="${it.displayRow}"
         >
 
-        <div class="title" style="background-color: ${it.build.iconColor.htmlBaseColor}; background-image:linear-gradient(${it.build.iconColor.htmlBaseColor}, white);">
-            <a href="${it.buildUrl}">${it.build.fullDisplayName}</a>
+        <div class="title" style="background-color: ${it.iconColor.htmlBaseColor}; background-image:linear-gradient(${it.iconColor.htmlBaseColor}, white);">
+            <a href="${it.buildUrl}">${it.fullDisplayName}</a>
         </div>
         <div class="details">
-            <j:if test="${!empty(it.build.description)}">
-                <j:out value="${app.markupFormatter.translate(it.build.description)}" />
+            <j:if test="${!empty(it.description)}">
+                <j:out value="${app.markupFormatter.translate(it.description)}" /><br/>
             </j:if>            
             <j:choose>
             <j:when test="${it.started}">
                 <j:choose>
-                <j:when test="${it.build.building}">
+                <j:when test="${it.building}">
                     <img title="Started" alt="Started" src="${rootURL}/images/16x16/clock.png"/> ${it.build.timestampString} ago<br/>
                     <t:buildProgressBar build="${it.build}"/>
                 </j:when>
                 <j:otherwise>
-                    Status: <span class="status"><t:buildStatusSummary build="${it.build}"/></span><br/>
+                    Status: ${it.buildSummaryStatusString}<br/>
                     <img title="Started" alt="Started" src="${rootURL}/images/16x16/clock.png"/> ${it.startTime}<br/>
-                    <img title="Duration" alt="Duration" src="${rootURL}/images/16x16/hourglass.png"/> ${it.build.durationString}<br/>
+                    <img title="Duration" alt="Duration" src="${rootURL}/images/16x16/hourglass.png"/> ${it.durationString}<br/>
                 </j:otherwise>
                 </j:choose>
                 <br/>


### PR DESCRIPTION
When build is finished and graph is generated. Serialize the graph so that it can be viewed even if part of the runs in the flow are removed. I do not know if this is of general interest as there are other ways to work around this.
