### PR TITLE
ISSUE-26610: Top-Level Matrix build is displayed by buildgraph

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,20 @@
       <version>2.18</version>
       <optional>true</optional>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.0.3-beta</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>1.7.1</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
   
   <repositories>

--- a/src/main/java/org/jenkinsci/plugins/buildgraphview/MatrixBuildDownstreamDeclarer.java
+++ b/src/main/java/org/jenkinsci/plugins/buildgraphview/MatrixBuildDownstreamDeclarer.java
@@ -1,0 +1,29 @@
+package org.jenkinsci.plugins.buildgraphview;
+
+import hudson.Extension;
+import hudson.matrix.MatrixBuild;
+import hudson.model.Run;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+/** Add all combination-builds of a Matrix-build to downstream-builds.
+ *
+ * Created by christianlangmann on 26/01/15.
+ */
+@Extension
+public class MatrixBuildDownstreamDeclarer extends DownStreamRunDeclarer {
+    @Override
+    public List<Run> getDownStream(Run r) throws ExecutionException, InterruptedException {
+
+        List<Run> runs = new ArrayList<Run>();
+        if (r instanceof MatrixBuild) {
+            final MatrixBuild matrixRun = (MatrixBuild)r;
+            for (Run downstreamRun : matrixRun.getExactRuns()) {
+                runs.add(downstreamRun);
+            }
+        }
+        return runs;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/buildgraphview/MatrixBuildDownstreamDeclarerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/buildgraphview/MatrixBuildDownstreamDeclarerTest.java
@@ -1,0 +1,64 @@
+package org.jenkinsci.plugins.buildgraphview;
+
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixRun;
+import hudson.model.Build;
+import hudson.model.Run;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.WithoutJenkins;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MatrixBuildDownstreamDeclarerTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @WithoutJenkins
+    @Test
+    public void testGetDownStream() throws Exception {
+        final MatrixRun runs[] = { mock(MatrixRun.class), mock(MatrixRun.class) };
+        final List<MatrixRun> expectedRuns = Arrays.asList(runs);
+        final MatrixBuild matrix = mock(MatrixBuild.class);
+        when(matrix.getExactRuns()).thenReturn(expectedRuns);
+        final MatrixBuildDownstreamDeclarer declarer = new MatrixBuildDownstreamDeclarer();
+        List<Run> result = declarer.getDownStream(matrix);
+        assertThat(result).containsOnlyElementsOf(expectedRuns);
+    }
+
+    @WithoutJenkins
+    @Test
+    public void testGetDownStreamForNonMatrixProject() throws Exception {
+        final Build matrix = mock(Build.class);
+        final MatrixBuildDownstreamDeclarer declarer = new MatrixBuildDownstreamDeclarer();
+        List<Run> result = declarer.getDownStream(matrix);
+        assertThat(result).isEmpty();
+    }
+
+    @WithoutJenkins
+    @Test
+    public void testGetDownStreamForEmptyMatrixProject() throws Exception {
+        final MatrixBuild matrix = mock(MatrixBuild.class);
+        final MatrixBuildDownstreamDeclarer declarer = new MatrixBuildDownstreamDeclarer();
+        List<Run> result = declarer.getDownStream(matrix);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testIsExtension() throws Exception {
+        final List<DownStreamRunDeclarer> all = DownStreamRunDeclarer.all();
+        assertThat(all).usingElementComparator(new Comparator<DownStreamRunDeclarer>() {
+            public int compare(DownStreamRunDeclarer o1, DownStreamRunDeclarer o2) {
+                return o1.getClass().toString().compareTo(o2.getClass().toString());
+            }
+        }).contains(new MatrixBuildDownstreamDeclarer());
+    }
+}


### PR DESCRIPTION
By simple using a Matrix-Downstream-Build-declarer, which returns the combinations of the Matrix-Build, the build graph shows a sensible build-flow for each combination at once.