### PR TITLE
[FIXED JENKINS-32499] BuildGraph doesn't show up if there is a null run

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildgraphview/BuildGraph.java
+++ b/src/main/java/org/jenkinsci/plugins/buildgraphview/BuildGraph.java
@@ -72,10 +72,12 @@ public class BuildGraph implements Action {
         for (DownStreamRunDeclarer declarer : DownStreamRunDeclarer.all()) {
             List<Run> runs = declarer.getDownStream(run);
             for (Run r : runs) {
-                BuildExecution next = getExecution(r);
-                graph.addVertex(next);
-                graph.addEdge(b, next, new Edge(b, next));
-                computeGraphFrom(next);
+                if (r !=null) {
+                    BuildExecution next = getExecution(r);
+                    graph.addVertex(next);
+                    graph.addEdge(b, next, new Edge(b, next));
+                    computeGraphFrom(next);
+                }
             }
         }
     }
@@ -118,7 +120,12 @@ public class BuildGraph implements Action {
 
     private BuildExecution getExecution(Run r) {
         for (BuildExecution buildExecution : graph.vertexSet()) {
-            if (buildExecution.getBuild().equals(r)) return buildExecution;
+            Run run = buildExecution.getBuild();
+            if(run!=null) {
+                if (run.equals(r)) {
+                    return buildExecution;
+                }
+            }
         }
         return new BuildExecution(r, ++index);
     }


### PR DESCRIPTION
The steps to re-produce this issue are explaining on the Jira issue.

Basically, the graph doesn't show up in case there are null run objects.

https://issues.jenkins-ci.org/browse/JENKINS-32499

@reviewbybees 