### PR TITLE
[FIXED JENKINS-23607] Do not block thread waiting for builds in queue…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildgraphview/FlowDownStreamRunDeclarer.java
+++ b/src/main/java/org/jenkinsci/plugins/buildgraphview/FlowDownStreamRunDeclarer.java
@@ -43,9 +43,11 @@ public class FlowDownStreamRunDeclarer extends DownStreamRunDeclarer {
         List<Run> runs = new ArrayList<Run>(edges.size());
         for (FlowRun.JobEdge edge : edges) {
             JobInvocation targetJobEdge = edge.getTarget();
-            Run run = targetJobEdge.getBuild();
-            if (run != null) {
-                runs.add(run);
+            if (targetJobEdge.isStarted()) {
+                Run run = targetJobEdge.getBuild();
+                if (run != null) {
+                    runs.add(run);
+                }
             }
         }
         return runs;


### PR DESCRIPTION
… to be scheduled

The json response handler calls getBuild() on all JobInvocations in the graph.
If a job is not scheduled (still in build queue), the call getBuild() is blocking.
This results in a HTTP request thread being blocked.
If enough such threads gets blocked, jenkins stops responding to HTTP requests all together.
To prevent this scenario this fix only calls getBuild() if the build has been started.