### PR TITLE
[FIXED JENKINS-41669] Buildgraph view does not show for som json resp…

### DIFF
--- a/src/main/webapp/scripts/buildgraph-appctrl.js
+++ b/src/main/webapp/scripts/buildgraph-appctrl.js
@@ -8,7 +8,12 @@ angular.module('buildgraphapp', [])
     $scope.callAtTimeout = function() {
         $http.get(ajaxPath)
             .then(function(response) {
-                var data = JSON.parse(response.data);
+                var data = response.data;
+                /* response.data can either be parsed JSON (object) or unparsed String() object
+                 * (or plain type string if angular implementation changes). */
+                if (typeof data === 'string' || data instanceof String) {
+                    data = JSON.parse(response.data);
+                }
                 var buildGraph = JSON.parse(data.buildGraph);
                 if(buildGraph.isBuilding || nodesSize != buildGraph.nodesSize || isBuilding != buildGraph.isBuilding) {
                     nodesSize = buildGraph.nodesSize;


### PR DESCRIPTION
…onses.

See jenkins issue https://issues.jenkins-ci.org/browse/JENKINS-41669 for full explanation.

To reproduce:

Use Firebug, Firefox developer or Chrome developer to set a break point in angular.js:9406 when viewing a build-graph view.
Step in the code to line 9411.
If data is of type "literal" string and tempData is of type String Object, then you will NOT be hit by this bug.
You have to find a build flow that cause line 9409 to return a string "literal".
I have not been able to hand craft a simple flow that will trigger the bug.
According to the specs, replace() and trim() should return a simple string, but for some reason returns a String object in most of the cases. If continueing to step the code you'll see that the call to fromJson() on line 9414 will not convert it to an object, but instead return the String-object as is.
However, if you do live edit of tempData to be a plain string with the same value, you'll see that fromJson will parse the content and return its object representation.

To really stress the point. The current implementation relies on a behavior that is most likely a bug in replace() or trim() since in all other use cases I've tried they will both return a string literal and not a String object which seems to be the norm in the buildgraph-view use. 

